### PR TITLE
Adjust Hashrate Meter

### DIFF
--- a/cpu-miner.c
+++ b/cpu-miner.c
@@ -1007,6 +1007,7 @@ static int share_result(int result, struct work *work, const char *reason)
 	case ALGO_CRYPTONIGHT:
 	case ALGO_PLUCK:
 	case ALGO_SCRYPTJANE:
+	case ALGO_LYRA2REV2:
 		sprintf(s, hashrate >= 1e6 ? "%.0f" : "%.2f", hashrate);
 		applog(LOG_NOTICE, "accepted: %lu/%lu (%s), %s H/s %s",
 			accepted_count, accepted_count + rejected_count,
@@ -2255,6 +2256,7 @@ static void *miner_thread(void *userdata)
 			case ALGO_CRYPTONIGHT:
 			case ALGO_PLUCK:
 			case ALGO_SCRYPTJANE:
+			case ALGO_LYRA2REV2:
 				applog(LOG_INFO, "CPU #%d: %.2f H/s", thr_id, thr_hashrates[thr_id]);
 				break;
 			default:
@@ -2274,6 +2276,7 @@ static void *miner_thread(void *userdata)
 				case ALGO_CRYPTONIGHT:
 				case ALGO_AXIOM:
 				case ALGO_SCRYPTJANE:
+				case ALGO_LYRA2REV2:
 					sprintf(s, "%.3f", hashrate);
 					applog(LOG_NOTICE, "Total: %s H/s", s);
 					break;


### PR DESCRIPTION
Due to the very low hashrate (~ 1 H/s per core) the hashmeter needs to display H/s instead of kH/s to show something meaningful.